### PR TITLE
Fix 'NoneType' object has no attribute 'split' error

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -63,6 +63,9 @@ def is_version_in_range(version: str, since_version: str, until_version: str) ->
     :param until_version: 最高支持版本（支持通配符，如'233.*'）
     :return: 是否在范围内
     """
+    if version is None:
+        return False
+
     # 移除版本号中的前缀（如'IU-'）
     version = version.split('-')[-1]
     
@@ -81,9 +84,9 @@ def fetch_latest_release(idea_version: str, build_version: str = None) -> dict:
     :param build_version: IDEA构建版本号（如'IU-243.26053.27'）
     """
     # 如果指定了idea_version，直接使用idea_version
-    matched_version = idea_version
+    matched_version = idea_version if idea_version else None
     # 如果没有提供idea_version, 则使用build_version进行匹配
-    if not matched_version:
+    if not matched_version and build_version:
         for version, info in plugin_info["versions"].items():
             if is_version_in_range(build_version, info["since_version"], info["until_version"]):
                 matched_version = version


### PR DESCRIPTION
Fix the 'NoneType' object has no attribute 'split' error in `api/index.py`.

* **Handle `None` version in `is_version_in_range` function**
  - Add a check if `version` is `None` before attempting to split it.

* **Handle `None` `idea_version` in `fetch_latest_release` function**
  - Default `idea_version` to `None` if not provided.
  - Add a check if `build_version` is `None` before attempting to split it.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/phodal/auto-dev-idea-repository/pull/1?shareId=ff9a558b-5e03-4da0-bf7d-a2e5615cedbf).